### PR TITLE
Add task to generate alternates for diacritics

### DIFF
--- a/src/glyphs/diacritics/uppercases/R/R_cap_alt_acute.coffee
+++ b/src/glyphs/diacritics/uppercases/R/R_cap_alt_acute.coffee
@@ -1,0 +1,20 @@
+exports.glyphs['R_cap_alt_acute'] =
+	unicode: 'Ŕ'
+	glyphName: 'Racute'
+	characterName: 'LATIN CAPITAL LETTER R WITH ACUTE'
+	base: 'R_cap_alt'
+	advanceWidth: base.advanceWidth
+	tags: [
+		'all',
+		'latin',
+		'uppercase',
+		'diacritic'
+	]
+	components:
+		0:
+			base: 'acute'
+			copy: true
+			parentAnchors:
+				0:
+					x: anchors[0].x
+					y: anchors[0].y

--- a/src/glyphs/diacritics/uppercases/R/R_cap_alt_caron.coffee
+++ b/src/glyphs/diacritics/uppercases/R/R_cap_alt_caron.coffee
@@ -1,0 +1,20 @@
+exports.glyphs['R_cap_alt_caron'] =
+	unicode: 'Ř'
+	glyphName: 'Rcaron'
+	characterName: 'LATIN CAPITAL LETTER R WITH CARON'
+	base: 'R_cap_alt'
+	advanceWidth: base.advanceWidth
+	tags: [
+		'all',
+		'latin',
+		'uppercase',
+		'diacritic'
+	]
+	components:
+		0:
+			base: 'caron'
+			copy: true
+			parentAnchors:
+				0:
+					x: anchors[0].x
+					y: anchors[0].y


### PR DESCRIPTION
Run the command like this: `gulp make:alternates`.
If some alternates have already been generated, a simple warning is shown
while it generates everything else. To overwrite everything, just use the
`--force` argument. If you want to regenerate for a specific character,
either delete the original generated file or by selecting with git what changes you
want to commit and resetting everything after.

Brought with an example of `R_cap_alt` diacritics generated.
